### PR TITLE
gp/don't include commits from master

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ async function main () {
         'log',
         '--format={"author": "%ae", "committer": "%ce", "sha": "%h"}',
         '--no-merges',
-        `${sha}..`
+        `${sha}..`,
+        '--not master'
       ],
       options
     )


### PR DESCRIPTION
the fix should fetch commits ignoring master branch and show only the current branch.