### PR TITLE
Change the order of the SHAs

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ async function main () {
         'log',
         '--format={"author": "%ae", "committer": "%ce", "sha": "%h"}',
         '--no-merges',
-        `${headSha}...${baseSha}`,
+        `${baseSha}..${headSha}`,
       ],
       options
     )


### PR DESCRIPTION
Previously,

```
kamal:envoy-web kamal$ git log --format='{"author": "%ae", "committer": "%ce", "sha": "%h"}' --no-merges ebb2ecced1f6686262b456e2baf660dee81ce10c...145122e3f8e279645f570a0873e77ec3f3f15bd1
{"author": "brian@envoy.com", "committer": "brianswko@gmail.com", "sha": "145122e3f"}
{"author": "kamal@envoy.com", "committer": "kamal@envoy.com", "sha": "ebb2ecced"}
```

It still pulled in the commit from master

With this change,

```
kamal:envoy-web kamal$ git log --format='{"author": "%ae", "committer": "%ce", "sha": "%h"}' --no-merges 145122e3f8e279645f570a0873e77ec3f3f15bd1..ebb2ecced1f6686262b456e2baf660dee81ce10c
{"author": "kamal@envoy.com", "committer": "kamal@envoy.com", "sha": "ebb2ecced"}
```